### PR TITLE
Add Laravel 10 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
   "minimum-stability": "stable",
   "require": {
     "php": "^7.1|^8",
-    "illuminate/database": "^6|^7|^8|^9"
+    "illuminate/database": "^6|^7|^8|^9|^10"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0|^8.0|^9.0",
+    "phpunit/phpunit": "^7.0|^8.0|^9.0|^10.0",
     "friendsofphp/php-cs-fixer": "^2.16|3.*",
     "squizlabs/php_codesniffer": "^3.5"
   },

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ composer require korridor/laravel-has-many-merged
 
 This package is tested for the following Laravel versions:
 
+- 10.* (PHP 8.1, 8.2)
 - 9.* (PHP 8.0, 8.1)
 - 8.* (PHP 7.3, 7.4, 8.0, 8.1)
 - 7.* (PHP 7.2, 7.3, 7.4)


### PR DESCRIPTION
This commit updates `composer.json` to allow support for the dependencies introduced in the upgrade procedure for Laravel 10.